### PR TITLE
Fixes non-existent isort version

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
       - id: mypy
 
   - repo: https://github.com/timothycrosley/isort
-    rev: v4.3.21-2
+    rev: 4.3.21-2
     hooks:
       - id: isort


### PR DESCRIPTION
I could not create the hook as-is, the reason is that the repo for isort doesn't seem to use the `v` prefix [ref](https://github.com/timothycrosley/isort/releases). Removing the `v` fixed it