### PR TITLE
Amend flake8 config to avoid rule conflicts with black

### DIFF
--- a/{{cookiecutter.project_slug}}/.flake8
+++ b/{{cookiecutter.project_slug}}/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
-max-complexity = 10
 extend-ignore = E203, W503
+max-complexity = 10

--- a/{{cookiecutter.project_slug}}/.flake8
+++ b/{{cookiecutter.project_slug}}/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 88
 max-complexity = 10
+extend-ignore = E203, W503


### PR DESCRIPTION
I ran into code formatting conflicts between `black` and `flake8` on the Microsoft Teams repo that derived from this template.

In accordance with https://black.readthedocs.io/en/stable/compatible_configs.html I've overridden the two flake8 rules that are known to conflict with black to prevent this in future projects.